### PR TITLE
Fixed command and parsing for inventorying running systemd services

### DIFF
--- a/policy/main.cf
+++ b/policy/main.cf
@@ -1,24 +1,23 @@
 bundle agent inventory_systemd_service_units_running
 # @brief Inventory systemd service units that are running
 # @inventory Systemd service units running
-# @dependencies systemctl, awk
+# @dependencies systemctl
 {
   vars:
     systemd::
-      "_cache" string => "$(sys.statedir)/systemd-units-running.dat";
+      "_cache" string => "$(sys.statedir)/systemd-units-running.json";
 
-      "_s"
-        slist => readstringlist( $(_cache), "", $(const.n), inf, inf),
-        if => fileexists( $(_cache) );
+      "_data" data => readjson("$(_cache)");
+      "_indices" slist => getindices(_data);
 
-      "i[$(_s)]"
-        string => "$(with)",
-        with => nth( string_split( $(_s), "\.service", inf ), 0 ),
+      "i[$(_indices)]"
+        string => "$(_data[$(_indices)][unit])",
         meta => { "inventory", "attribute_name=Systemd service units running"};
+
 
   commands:
     systemd::
-      "$(paths.systemctl) list-units --type=service --state=running | awk '/^UNIT .*/{flag=1;next}/^$/{flag=0}flag{print $1}' > $(_cache)"
+      "$(paths.systemctl) list-units --type=service --state=running --output=json > $(_cache)"
         contain => in_shell;
 
 }


### PR DESCRIPTION
The awk command just looks wrong to me.
^UNIT should match lines starting with UNIT.
The output of systemctl list-units on debian-11 has UNIT with some spaces at the beginning.
Also, later in the output some other footer elements are present.

Not sure when and where this systemctl | awk command worked but with debian-11, systemctl 247 it doesn't and --output=json is a nice option.
